### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -111,7 +111,7 @@ class syntax_plugin_button extends DokuWiki_Syntax_Plugin {
 		return (is_array($this->targets[$ID]) && array_key_exists($name,$this->targets[$ID])) ? true : false;
 	}
 	
-    function handle($match, $state, $pos, &$handler)
+    function handle($match, $state, $pos, Doku_Handler $handler)
     { 
 		global $plugin_button_styles;
 		global $plugin_button_target;
@@ -169,7 +169,7 @@ class syntax_plugin_button extends DokuWiki_Syntax_Plugin {
         return array();
     }
     
-    function render($mode, &$renderer, $data) 
+    function render($mode, Doku_Renderer $renderer, $data) 
     {
 		global $plugin_button_styles;
 		global $plugin_button_target;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
