### PR TITLE
Fixed deprecation warnings in PHP 8+ (issue #30 and issue #32).

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   button
 author Remi Peyronnet
 email  remi+button@via.ecp.fr
-date   2023-05-29
+date   2023-08-18
 name   Button Plugin
 desc   Add button links syntax
 url    https://www.dokuwiki.org/plugin:button


### PR DESCRIPTION
Hi @rpeyron !

Continuing our conversation in issue #32 and #30,  I merged your solution from commit d52dfe34b7804d1decf1b7a41f4719b98bd877a9 with mine from the file I shared in #32, and I managed to fix it. The warnings are gone and the buttons are working and redirecting to the right place (fixed issue #30).

Also changed a few hard tabs (`\t`) to soft tabs (4 spaces) to keep script standard.

I hope you do your own tests too.

Thanks for keeping this plugin up to date. Many are now abandoned by their maintainers.